### PR TITLE
fix: updated broken links

### DIFF
--- a/content/en_index.php
+++ b/content/en_index.php
@@ -120,7 +120,7 @@ setTimeout(function () {
       <p><a class="btn btn-warning" href="https://www.eclipse.org/downloads/download.php?file=/kura/releases/5.2.0/kura_5.2.0_raspberry-pi_installer.deb">Download</a></p>
       <p>To install, follow these instructions:
       </p>
-      <p><a class="btn btn-info" href="http://eclipse.github.io/kura/docs-release-5.2/getting-started/raspberry-pi-raspberryos-quick-start/">Install Instructions</a></p>
+      <p><a class="btn btn-info" href="https://eclipse.github.io/kura/docs-release-5.2/getting-started/raspberry-pi-raspberryos-quick-start/">Install Instructions</a></p>
       <hr>
       <p><b>Docker</b> run: <b>docker run -d -p 8443:443 -t eclipse/kura</b></p>
       <p><a class="btn btn-warning" href="https://github.com/eclipse/kura/tree/develop/kura/container">Documentation</a></p>
@@ -133,15 +133,15 @@ setTimeout(function () {
       <h1 class="fw-600">Connect</h1>
       <p>Use <b>Wires</b> to visually connect your sensors and PLCs using a friendly web UI for data capture, processing and publishing.
       </p>
-      <p><a class="btn btn-info" href="//eclipse.github.io/kura/wires/kura-wires-intro.html">Learn More</a></p>
+      <p><a class="btn btn-info" href="https://eclipse.github.io/kura/docs-develop/kura-wires/introduction/">Learn More</a></p>
     </div>
     <div class="col-md-8 three gs-item">
       <div class="circle">3</div>
       <h1 class="fw-600">Extend</h1>
       <p>Develop new Components and Application, Drag-and-Drop new modules from the Eclipse IoT Marketplace.</p>
       <ul>
-        <li>Get Started with the <a href="http://eclipse.github.io/kura/builtin/intro.html">Framework Functionalities</a></li>
-        <li>Get Started with <a href="http://eclipse.github.io/kura/dev/kura-setup.html">Java development</a></li>
+        <li>Get Started with the <a href="https://eclipse.github.io/kura/docs-develop/">Framework Functionalities</a></li>
+        <li>Get Started with <a href="https://eclipse.github.io/kura/docs-develop/java-application-development/development-environment-setup/">Java development</a></li>
         <li>Access the <a href="//marketplace.eclipse.org/taxonomy/term/4397%2C4396/title">Marketplace</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Updated broken links:
- Added `https` to Raspberry Pi "Getting started" page
- Correct link to Kura Wires introduction
- Correct link to Framework introduction page
- Correct link to Development Environment instruction page